### PR TITLE
main to CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install --editable .
 
 The example and explanations below are based on the script's behaviour on Python 3.8
 
-Use an API key provided to you from NCBI in the ```.env``` file for the expected workings of this program.
+Use an API key provided to you from NCBI in the `.env` file for the expected workings of this program.
 
 ### Public methods
 
@@ -58,58 +58,31 @@ This method also returns a list of all PMID's that were uploaded in the requeste
 
 #### Example
 
-An example usage is by getting the list of PMID's from ```get_list_pmid``` and then passing that list to the ```uids_to_docs``` for the data of all the PMID's in the given time frame.
+An example usage is by getting the list of PMID's from `get_list_pmid` and then passing that list to the `uids_to_docs` for the data of all the PMID's in the given time frame.
 
 ### Command line
 
-Can be run on Command line with the command, look below for required arguments
+Can be run on Command line. Call the below command for usage details
 
 ```bash
-main.py --help
-```
-This prints out:
-
-```bash
-Usage: main.py [OPTIONS] START END REQUEST_FILE
-
-  Main requires 3 arguments.
-
-  The first one is start date (eg: YYYY/MM/DD).
-
-  The second one is end date (eg: 2021/02/05).
-
-  The third one is the filename where the data needs to be written to.
-
-Arguments:
-  START         [required]
-  END           [required]
-  REQUEST_FILE  [required]
-
-Options:
-  --install-completion [bash|zsh|fish|powershell|pwsh]
-                                  Install completion for the specified shell.
-  --show-completion [bash|zsh|fish|powershell|pwsh]
-                                  Show completion for the specified shell, to
-                                  copy it or customize the installation.
-
-  --help                          Show this message and exit.
+pubmed-dl --help
 ```
 
 Program requires three arguments to be inputted by the user. 
-The first one is the start date in the ```YYYY/MM/DD``` format (e.g.: ```2021/02/04```). 
-The second one is the end date in the ```YYYY/MM/DD``` format (e.g.: ```2021/02/05```). 
-The third one is the filename where the data needs to be written to (e.g.: ```test.json```).
+The first one is the start date in the `YYYY/MM/DD` format (e.g.: `2021/02/04`). 
+The second one is the end date in the `YYYY/MM/DD` format (e.g.: `2021/02/05`). 
+The third one is the filename where the data needs to be written to (e.g.: `test.json`).
 
-An example input to retrieve the data from ```2021/02/04``` to ```2021/02/05``` and store the data to a file named ```test.json``` would look like:
+An example input to retrieve the data from `2021/02/04` to `2021/02/05` and store the data to a file named `test.json` would look like:
 
 ```bash
 main.py 2021/02/04 2021/02/05 test.json
 ```
 
-The Program then runs and outputs the total records and an URL for every 10,000 records, until all records have been downloaded. Immediately after this the program grabs the PMID's of all the records and then passes the list of PMID's to the ```uids_to_docs``` method, which then gets all the data (Title, Abstract) and writes it to a file named ```test.json```.
+The Program then runs and outputs the total records and an URL for every 10,000 records, until all records have been downloaded. Immediately after this the program grabs the PMID's of all the records and then passes the list of PMID's to the `uids_to_docs` method, which then gets all the data (Title, Abstract) and writes it to a file named `test.json`.
 
 After the Program is finished running, it will output a statement.
 
 ```bash
-Done writing data from "start date" to "end date" onto file named: ```your file name```
+Done writing data from "start date" to "end date" onto file named: `your file name`
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The third one is the filename where the data needs to be written to (e.g.: `test
 An example input to retrieve the data from `2021/02/04` to `2021/02/05` and store the data to a file named `test.json` would look like:
 
 ```bash
-main.py 2021/02/04 2021/02/05 test.json
+pubmed-dl 2021/02/04 2021/02/05 test.json
 ```
 
 The Program then runs and outputs the total records and an URL for every 10,000 records, until all records have been downloaded. Immediately after this the program grabs the PMID's of all the records and then passes the list of PMID's to the `uids_to_docs` method, which then gets all the data (Title, Abstract) and writes it to a file named `test.json`.

--- a/README.md
+++ b/README.md
@@ -62,17 +62,48 @@ An example usage is by getting the list of PMID's from ```get_list_pmid``` and t
 
 ### Command line
 
-Can be run on Command line with the command
+Can be run on Command line with the command, look below for required arguments
 
 ```bash
-pubmed-dl
+main.py --help
+```
+This prints out:
+
+```bash
+Usage: main.py [OPTIONS] START END REQUEST_FILE
+
+  Main requires 3 arguments.
+
+  The first one is start date (eg: YYYY/MM/DD).
+
+  The second one is end date (eg: 2021/02/05).
+
+  The third one is the filename where the data needs to be written to.
+
+Arguments:
+  START         [required]
+  END           [required]
+  REQUEST_FILE  [required]
+
+Options:
+  --install-completion [bash|zsh|fish|powershell|pwsh]
+                                  Install completion for the specified shell.
+  --show-completion [bash|zsh|fish|powershell|pwsh]
+                                  Show completion for the specified shell, to
+                                  copy it or customize the installation.
+
+  --help                          Show this message and exit.
 ```
 
-Program requires two dates to be inputted for start and end
+Program requires three arguments to be inputted by the user. 
+The first one is the start date in the ```YYYY/MM/DD``` format (e.g.: ```2021/02/04```). 
+The second one is the end date in the ```YYYY/MM/DD``` format (e.g.: ```2021/02/05```). 
+The third one is the filename where the data needs to be written to (e.g.: ```test.json```).
+
+An example input to retrieve the data from ```2021/02/04``` to ```2021/02/05``` and store the data to a file named ```test.json``` would look like:
 
 ```bash
-Enter start date (YYYY/MM/DD): "Enter your start date here"
-Enter end date (YYYY/MM/DD): "Enter your end date here"
+main.py 2021/02/04 2021/02/05 test.json
 ```
 
 The Program then runs and outputs the total records and an URL for every 10,000 records, until all records have been downloaded. Immediately after this the program grabs the PMID's of all the records and then passes the list of PMID's to the ```uids_to_docs``` method, which then gets all the data (Title, Abstract) and writes it to a file named ```test.json```.
@@ -80,5 +111,5 @@ The Program then runs and outputs the total records and an URL for every 10,000 
 After the Program is finished running, it will output a statement.
 
 ```bash
-Done writing data from "start date" to "end date" onto file named: test.json
+Done writing data from "start date" to "end date" onto file named: ```your file name```
 ```

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -1,15 +1,16 @@
 import json
+import typer
 from pubmed_dl.ncbi import get_list_pmid, uids_to_docs
 
-def main():
-    start = input("Enter start date (YYYY/MM/DD): ")
-    end = input("Enter end date (YYYY/MM/DD): ")
-    val = get_list_pmid(start,end)
+def main(start: str, end: str):
+    start_date = start
+    end = end
+    val = get_list_pmid(start_date,end)
     with open("test.json", "w") as f:
         for batch in uids_to_docs(val):
             for doc in batch:
                 f.write(f"{json.dumps(doc)}\n")
-    print(f"Done writing data from {start} to {end} onto file named: test.json")
+    print(f"Done writing data from {start_date} to {end} onto file named: test.json")
 
 if __name__ == "__main__":
-    main()
+    typer.run(main)

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -21,7 +21,7 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start: str, end: str, request_file: str):
+def main(start_date: str, end_date: str, request_file: str):
     """
     Main requires 3 arguments. 
     
@@ -35,8 +35,6 @@ def main(start: str, end: str, request_file: str):
     start_time = time.time()
     output_filepath: Path = Path(request_file)
     output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
-    start_date = start
-    end_date = end
     pmids = get_list_pmid(start_date, end_date)
     with open(output_filepath, "w") as f:
         for batch in uids_to_docs(pmids):

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -1,16 +1,39 @@
 import json
-import typer
 from pubmed_dl.ncbi import get_list_pmid, uids_to_docs
+import logging
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from pydantic import BaseSettings
+import time
+import typer
+
+
+dot_env_filepath = Path(__file__).absolute().parent.parent / ".env"
+load_dotenv(dot_env_filepath)
+
+
+class Settings(BaseSettings):
+    loglevel: str = os.getenv("LOGLEVEL", "INFO")
+
+
+settings = Settings()
+logging.basicConfig(level=settings.loglevel)
+
 
 def main(start: str, end: str):
+    start_time = time.time()
     start_date = start
     end_date = end
-    val = get_list_pmid(start_date,end_date)
+    val = get_list_pmid(start_date, end_date)
     with open("test.json", "w") as f:
         for batch in uids_to_docs(val):
             for doc in batch:
                 f.write(f"{json.dumps(doc)}\n")
-    print(f"Done writing data from {start_date} to {end_date} onto file named: test.json")
+    logging.info(f"Done writing data from {start_date} to {end_date} onto file named: test.json")
+    duration = time.time() - start_time
+    logging.info(f"Total run time for {len(val)} docs: {duration}s")
+
 
 if __name__ == "__main__":
     typer.run(main)

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from pydantic import BaseSettings
 import time
+import typer
 from typing import Optional
 
 

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -7,7 +7,6 @@ from dotenv import load_dotenv
 from pydantic import BaseSettings
 import time
 import typer
-from typing import Optional
 
 
 dot_env_filepath = Path(__file__).absolute().parent.parent / ".env"
@@ -22,22 +21,21 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start: str, end: str, request_file: Optional[str] = typer.Argument(None)):
+def main(start: str, end: str, request_file: str):
     """
-    Main requires 2 arguments and an optional 3rd argument. 
+    Main requires 3 arguments. 
     
     The first one is start date (eg: YYYY/MM/DD).
+
     The second one is end date (eg: 2021/02/05).
     
-    The third one is the filename where the data needs to be written to, 
-    if not specified it will be written to 'test.json'.
+    The third one is the filename where the data needs to be written to.
 
     """
     start_time = time.time()
-    if request_file is None:
-        filename = "test.json"
-    else:
-        filename = request_file
+    output_filepath: Path = Path(request_file)
+    output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
+    filename = request_file
     start_date = start
     end_date = end
     pmids = get_list_pmid(start_date, end_date)

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -35,15 +35,14 @@ def main(start: str, end: str, request_file: str):
     start_time = time.time()
     output_filepath: Path = Path(request_file)
     output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
-    filename = request_file
     start_date = start
     end_date = end
     pmids = get_list_pmid(start_date, end_date)
-    with open(filename, "w") as f:
+    with open(output_filepath, "w") as f:
         for batch in uids_to_docs(pmids):
             for doc in batch:
                 f.write(f"{json.dumps(doc)}\n")
-    logging.info(f"Done writing data from {start_date} to {end_date} onto file named: {filename}")
+    logging.info(f"Done writing data from {start_date} to {end_date} onto file named: {output_filepath}")
     duration = time.time() - start_time
     logging.info(f"Total run time for {len(pmids)} docs: {duration}s")
 

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -4,13 +4,13 @@ from pubmed_dl.ncbi import get_list_pmid, uids_to_docs
 
 def main(start: str, end: str):
     start_date = start
-    end = end
-    val = get_list_pmid(start_date,end)
+    end_date = end
+    val = get_list_pmid(start_date,end_date)
     with open("test.json", "w") as f:
         for batch in uids_to_docs(val):
             for doc in batch:
                 f.write(f"{json.dumps(doc)}\n")
-    print(f"Done writing data from {start_date} to {end} onto file named: test.json")
+    print(f"Done writing data from {start_date} to {end_date} onto file named: test.json")
 
 if __name__ == "__main__":
     typer.run(main)

--- a/pubmed_dl/main.py
+++ b/pubmed_dl/main.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from pydantic import BaseSettings
 import time
 import typer
+from typing import Optional
 
 
 dot_env_filepath = Path(__file__).absolute().parent.parent / ".env"
@@ -21,18 +22,32 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start: str, end: str):
+def main(start: str, end: str, request_file: Optional[str] = typer.Argument(None)):
+    """
+    Main requires 2 arguments and an optional 3rd argument. 
+    
+    The first one is start date (eg: YYYY/MM/DD).
+    The second one is end date (eg: 2021/02/05).
+    
+    The third one is the filename where the data needs to be written to, 
+    if not specified it will be written to 'test.json'.
+
+    """
     start_time = time.time()
+    if request_file is None:
+        filename = "test.json"
+    else:
+        filename = request_file
     start_date = start
     end_date = end
-    val = get_list_pmid(start_date, end_date)
-    with open("test.json", "w") as f:
-        for batch in uids_to_docs(val):
+    pmids = get_list_pmid(start_date, end_date)
+    with open(filename, "w") as f:
+        for batch in uids_to_docs(pmids):
             for doc in batch:
                 f.write(f"{json.dumps(doc)}\n")
-    logging.info(f"Done writing data from {start_date} to {end_date} onto file named: test.json")
+    logging.info(f"Done writing data from {start_date} to {end_date} onto file named: {filename}")
     duration = time.time() - start_time
-    logging.info(f"Total run time for {len(val)} docs: {duration}s")
+    logging.info(f"Total run time for {len(pmids)} docs: {duration}s")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
         "requests>=2.25.1",
         "pydantic>=1.7.3",
         "python-dotenv>=0.15.0",
+        "typer>=0.3.2",
     ],
     extras_require={
         "dev": ["black", "coverage", "codecov", "flake8", "pytest", "pytest-cov", "mypy"]


### PR DESCRIPTION
# Overview

Have 2 required arguments set up for start and end dates respectively
```main.py --help``` shows this:
```bash
C:\Users\anwes\Desktop\pupul\BaderLab\Pubmed\semantic_git\pubmed-dl\pubmed_dl>py main.py --help
Usage: main.py [OPTIONS] START END

Arguments:
  START  [required]
  END    [required]

Options:
  --install-completion [bash|zsh|fish|powershell|pwsh]
                                  Install completion for the specified shell.
  --show-completion [bash|zsh|fish|powershell|pwsh]
                                  Show completion for the specified shell, to
                                  copy it or customize the installation.

  --help                          Show this message and exit.
```
for the testing run any dates:
```main.py 2021/02/05 2021/02/05```
should work and write to the ```test.json``` file

## Closes

Closes #12.