### PR TITLE
Fix pubmed-dl command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/pubmed_dl/__init__.py
+++ b/pubmed_dl/__init__.py
@@ -1,1 +1,1 @@
-from pubmed_dl.main import uids_to_docs, get_list_pmid
+from pubmed_dl.ncbi import get_list_pmid, uids_to_docs

--- a/pubmed_dl/bin/pubmed-dl
+++ b/pubmed_dl/bin/pubmed-dl
@@ -1,13 +1,15 @@
+#!/usr/bin/env python
 import json
-from pubmed_dl.ncbi import get_list_pmid, uids_to_docs
 import logging
 import os
+import time
 from pathlib import Path
+
+import typer
 from dotenv import load_dotenv
 from pydantic import BaseSettings
-import time
-import typer
 
+from pubmed_dl.ncbi import get_list_pmid, uids_to_docs
 
 dot_env_filepath = Path(__file__).absolute().parent.parent / ".env"
 load_dotenv(dot_env_filepath)
@@ -23,12 +25,12 @@ logging.basicConfig(level=settings.loglevel)
 
 def main(start_date: str, end_date: str, request_file: str):
     """
-    Main requires 3 arguments. 
-    
+    Main requires 3 arguments.
+
     The first one is start date (eg: YYYY/MM/DD).
 
     The second one is end date (eg: 2021/02/05).
-    
+
     The third one is the filename where the data needs to be written to.
 
     """
@@ -40,11 +42,12 @@ def main(start_date: str, end_date: str, request_file: str):
         for batch in uids_to_docs(pmids):
             for doc in batch:
                 f.write(f"{json.dumps(doc)}\n")
-    logging.info(f"Done writing data from {start_date} to {end_date} onto file named: {output_filepath}")
+    logging.info(
+        f"Done writing data from {start_date} to {end_date} onto file named: {output_filepath}"
+    )
     duration = time.time() - start_time
     logging.info(f"Total run time for {len(pmids)} docs: {duration}s")
 
 
 if __name__ == "__main__":
     typer.run(main)
-

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Typing :: Typed",
     ],
-    entry_points={
-        "console_scripts": ["pubmed-dl=pubmed_dl.main:main"],
-    },
-    python_requires=">=3.8.0",
+    scripts=["pubmed_dl/bin/pubmed-dl"],
+    python_requires=">=3.8.0,<3.9.0",
     install_requires=[
         "biopython>=1.78",
         "requests>=2.25.1",


### PR DESCRIPTION
# Overview

This fixes the `pubmed-dl` command by restructuring a little (put all scripts under `bin`) and switching the `console_scripts` keyword for the `scripts` keyword in `setup.py`. Users can now call

```bash
pubmed-dl --help
```

as expected.

## Other changes

- Pin `python>=3.8.0,<3.9.0` because `biopython` does not support it.
- The import in `pubmed_dl/__init__.py` was incorrect, fixed.

## Closes

Closes #20.