### PR TITLE
Progress bar made optional

### DIFF
--- a/pubmed_dl/bin/pubmed-dl
+++ b/pubmed_dl/bin/pubmed-dl
@@ -23,7 +23,13 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start_date: str = typer.Argument("",help = "The start date for data retrieval"), end_date: str = typer.Argument("",help = "The end date for data retrieval"), request_file: str = typer.Argument("",help = "The filename to write retrieved data to"), progress_bar: bool = typer.Option(True, help = "To display progress bar")):
+def main(start_date: str = typer.Argument(...,help = "The start date for data retrieval"), end_date: str = typer.Argument(...,help = "The end date for data retrieval"), request_file: str = typer.Argument(...,help = "The filename to write retrieved data to"), progress_bar: bool = typer.Option(True, help = "To display progress bar")):
+    """
+    The data to be downloaded is done in batches of articles from PubMed that are
+    published between start_date and end_date.
+
+    The request_file is where the retrieved data, is finally written to.
+    """
     start_time = time.time()
     output_filepath: Path = Path(request_file)
     output_filepath.parents[0].mkdir(parents=True, exist_ok=True)

--- a/pubmed_dl/bin/pubmed-dl
+++ b/pubmed_dl/bin/pubmed-dl
@@ -6,7 +6,6 @@ import time
 from pathlib import Path
 
 import typer
-from typing import Optional
 from dotenv import load_dotenv
 from pydantic import BaseSettings
 

--- a/pubmed_dl/bin/pubmed-dl
+++ b/pubmed_dl/bin/pubmed-dl
@@ -23,17 +23,7 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start_date: str, end_date: str, request_file: str, progress_bar: bool = typer.Option(True)):
-    """
-    Main requires 3 arguments.
-
-    The first one is start date (eg: YYYY/MM/DD).
-
-    The second one is end date (eg: 2021/02/05).
-
-    The third one is the filename where the data needs to be written to.
-
-    """
+def main(start_date: str = typer.Argument("",help = "The start date for data retrieval"), end_date: str = typer.Argument("",help = "The end date for data retrieval"), request_file: str = typer.Argument("",help = "The filename to write retrieved data to"), progress_bar: bool = typer.Option(True, help = "To display progress bar")):
     start_time = time.time()
     output_filepath: Path = Path(request_file)
     output_filepath.parents[0].mkdir(parents=True, exist_ok=True)

--- a/pubmed_dl/bin/pubmed-dl
+++ b/pubmed_dl/bin/pubmed-dl
@@ -24,7 +24,7 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start_date: str, end_date: str, request_file: str, progress_bar: Optional[bool] = typer.Argument(True)):
+def main(start_date: str, end_date: str, request_file: str, progress_bar: bool = typer.Option(True)):
     """
     Main requires 3 arguments.
 

--- a/pubmed_dl/bin/pubmed-dl
+++ b/pubmed_dl/bin/pubmed-dl
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 import typer
+from typing import Optional
 from dotenv import load_dotenv
 from pydantic import BaseSettings
 
@@ -23,7 +24,7 @@ settings = Settings()
 logging.basicConfig(level=settings.loglevel)
 
 
-def main(start_date: str, end_date: str, request_file: str):
+def main(start_date: str, end_date: str, request_file: str, progress_bar: Optional[bool] = typer.Argument(True)):
     """
     Main requires 3 arguments.
 
@@ -38,14 +39,13 @@ def main(start_date: str, end_date: str, request_file: str):
     output_filepath: Path = Path(request_file)
     output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
     pmids = get_list_pmid(start_date, end_date)
-    count = 0
     with open(output_filepath, "w") as f:
         with typer.progressbar(length = len(pmids), label = "Processing") as progress:
             for batch in uids_to_docs(pmids):
                     for doc in batch:
                         f.write(f"{json.dumps(doc)}\n")
-                        count += 1
-                        progress.update(1)
+                        if progress_bar is True:
+                            progress.update(1)
                     print("")
     logging.info(
         f"Done writing data from {start_date} to {end_date} onto file named: {output_filepath}"


### PR DESCRIPTION
@maxkfranz this is addressing the last comment of PR #23  

This makes the progress bar optional (default is set to display) if you don't want to display make the 4th command on the CLI as `False`. An example command for running without a progress bar is:
``` bash
pubmed-dl 2021/02/05 2021/02/07 test.json False
```


